### PR TITLE
fix: vertical line matching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+r/src/rust/rust

--- a/justfile
+++ b/justfile
@@ -1,0 +1,2 @@
+fmt:
+  cargo fmt --all

--- a/r/bootstrap.R
+++ b/r/bootstrap.R
@@ -8,7 +8,7 @@ if (!requireNamespace("fs")) {
 }
 
 if (!requireNamespace("rextendr")) {
-  error("bootstrap.R requires `fs` to be installed.")
+  error("bootstrap.R requires `rextendr` to be installed.")
 }
 
 
@@ -77,7 +77,6 @@ workspace_toml <- read_toml(
 # extract workspace specific metadata from the manifest path
 workspace_fields <- get_item(workspace_toml, "workspace")
 
-
 # workspace members that are deps index:
 workspace_idx <- which(
   pkg_metadata$packages$name %in% names(pkg_deps)
@@ -95,12 +94,22 @@ workspace_member_dep_paths <- basename(
 # "." is the R package workspace info
 workspace_fields$members <- c(".", workspace_member_dep_paths)
 
+for (i in seq_along(workspace_fields$dependencies)) {
+  dep <- workspace_fields$dependencies[[i]]
+  if (is.list(dep)) {
+    # cast to list
+    dep$features <- as.list(dep$features)
+    workspace_fields$dependencies[[i]] <- dep
+  }
+}
+
 # iterate through deps and copy them to the workspace
 for (.dep in non_reg_deps$path) {
   dest <- file.path("src/rust", basename(.dep))
   info("Copying dep", .dep, " into ", dest)
   fs::dir_copy(.dep, dest, overwrite = TRUE)
 }
+
 
 # insert the workspace settings into the R package's Cargo.toml
 info("Updating workspace settings!")

--- a/r/src/rust/Cargo.lock
+++ b/r/src/rust/Cargo.lock
@@ -1522,8 +1522,3 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[patch.unused]]
-name = "extendr-api"
-version = "0.7.1"
-source = "git+https://github.com/extendr/extendr?rev=2c2749f5e9d13d5628399c8779c47d420246a4a1#2c2749f5e9d13d5628399c8779c47d420246a4a1"

--- a/r/src/rust/Cargo.toml
+++ b/r/src/rust/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "anime_r"
-version.workspace = true
-edition.workspace = true
-rust-version.workspace = true
+version = "0.2.0"
+edition = "2021"
+rust-version = "1.90"
 publish = false
 
 [lib]
@@ -19,3 +19,14 @@ geo-traits = { workspace = true }
 geoarrow = { workspace = true }
 geoarrow-array = { workspace = true }
 itertools = "0.12.0"
+
+[workspace]
+resolver = "2"
+members = [".", "rust"]
+package = { version = "0.2.0", edition = "2021", rust-version = "1.90" }
+dependencies = { anime = { path = "rust", features = [
+] }, arrow = { version = "55", default-features = false, features = [
+] }, geo = "0.29.3", geo-traits = "0.3.0", geo-types = { version = "0.7.12", features = [
+  "use-rstar_0_11",
+] }, geoarrow = "0.4.0", geoarrow-array = "0.4.0", rstar = "0.11.0" }
+lints = { rust = { unsafe_code = "forbid" } }

--- a/r/src/rust/Cargo.toml
+++ b/r/src/rust/Cargo.toml
@@ -19,14 +19,3 @@ geo-traits = { workspace = true }
 geoarrow = { workspace = true }
 geoarrow-array = { workspace = true }
 itertools = "0.12.0"
-
-[workspace]
-resolver = "2"
-members = [".", "rust"]
-package = { version = "0.2.0", edition = "2021", rust-version = "1.90" }
-dependencies = { anime = { path = "rust", features = [
-] }, arrow = { version = "55", default-features = false, features = [
-] }, geo = "0.29.3", geo-traits = "0.3.0", geo-types = { version = "0.7.12", features = [
-  "use-rstar_0_11",
-] }, geoarrow = "0.4.0", geoarrow-array = "0.4.0", rstar = "0.11.0" }
-lints = { rust = { unsafe_code = "forbid" } }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -168,8 +168,8 @@ fn find_candidate_matches(
         let (j, y_slope) = cy.data;
 
         // convert calculated slopes to degrees
-        let x_deg = x_slope.atan().to_degrees();
-        let y_deg = y_slope.atan().to_degrees();
+        let x_deg = x_slope.abs().atan().to_degrees();
+        let y_deg = y_slope.abs().atan().to_degrees();
 
         // compare slopes:
         let is_tolerant = (x_deg - y_deg).abs() < angle_tolerance;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -167,9 +167,9 @@ fn find_candidate_matches(
         let (i, x_slope) = cx.data;
         let (j, y_slope) = cy.data;
 
-        // convert calculated slopes to degrees
-        let x_deg = x_slope.abs().atan().to_degrees();
-        let y_deg = y_slope.abs().atan().to_degrees();
+        // convert calculated slopes to degrees normalize to 180
+        let x_deg = (x_slope.atan().to_degrees() + 180.0) % 180.0;
+        let y_deg = (y_slope.atan().to_degrees() + 180.0) % 180.0;
 
         // compare slopes:
         let is_tolerant = (x_deg - y_deg).abs() < angle_tolerance;

--- a/rust/src/overlap.rs
+++ b/rust/src/overlap.rs
@@ -147,7 +147,6 @@ mod tests {
 
         // Source A (CLOSE, ~2m away): leaning slightly RIGHT (opposite slope sign)
         // dx = +0.5 -> slope ≈ +100
-        // This should MATCH but was being rejected before the fix
         let source_close =
             LineString::new(vec![coord! {x: 102.0, y: 0.0}, coord! {x: 102.5, y: 50.0}]);
 

--- a/rust/src/overlap.rs
+++ b/rust/src/overlap.rs
@@ -127,4 +127,104 @@ mod tests {
         assert_eq!(overlap.start, 5.0);
         assert_eq!(overlap.end, 10.0);
     }
+
+    // https://github.com/JosiahParry/anime/issues/59
+    // This reproduces the issue where two parallel near-vertical lines
+    // can have opposite slope signs (one +89°, one -89°) depending on
+    // whether dx is positive or negative, causing them to appear ~178° apart
+    // and fail angle tolerance checks even though they are genuinely parallel.
+    #[test]
+    fn test_near_vertical_parallel_lines() {
+        use crate::Anime;
+        use geo_types::{coord, LineString};
+
+        // Target line: going north, leaning very slightly left
+        // dx = -0.5, dy = 50 -> slope ≈ -100
+        let target = vec![LineString::new(vec![
+            coord! {x: 100.0, y: 0.0},
+            coord! {x: 99.5, y: 50.0},
+        ])];
+
+        // Source A (CLOSE, ~2m away): leaning slightly RIGHT (opposite slope sign)
+        // dx = +0.5 -> slope ≈ +100
+        // This should MATCH but was being rejected before the fix
+        let source_close =
+            LineString::new(vec![coord! {x: 102.0, y: 0.0}, coord! {x: 102.5, y: 50.0}]);
+
+        // Source B (FAR, ~10m away): leaning slightly left (same slope sign as target)
+        // dx = -0.5 -> slope ≈ -100
+        let source_far =
+            LineString::new(vec![coord! {x: 110.0, y: 0.0}, coord! {x: 109.5, y: 50.0}]);
+
+        let sources = vec![source_close, source_far];
+
+        let anime = Anime::new(sources.into_iter(), target.into_iter(), 15.0, 20.0);
+
+        let matches = anime.matches.get().unwrap();
+
+        // Both sources should match the target since they are both parallel
+        // and within distance tolerance
+        if let Some(target_matches) = matches.get(&0) {
+            // We expect BOTH source lines to match (source_id 0 and 1)
+            assert_eq!(
+                target_matches.len(),
+                2,
+                "Both near-vertical parallel lines should match regardless of slope sign"
+            );
+
+            // Verify both source indices are present
+            let source_indices: Vec<usize> =
+                target_matches.iter().map(|m| m.source_index).collect();
+            assert!(
+                source_indices.contains(&0),
+                "Close source (opposite slope sign) should match"
+            );
+            assert!(
+                source_indices.contains(&1),
+                "Far source (same slope sign) should match"
+            );
+        } else {
+            panic!("Target should have matches");
+        }
+    }
+
+    // https://github.com/JosiahParry/anime/issues/59
+    #[test]
+    fn test_diagonal_parallel_lines() {
+        use crate::Anime;
+        use geo_types::{coord, LineString};
+
+        // Target line at ~45° angle
+        let target = vec![LineString::new(vec![
+            coord! {x: 0.0, y: 0.0},
+            coord! {x: 40.0, y: 50.0},
+        ])];
+
+        // Two parallel sources, shifted left and right
+        let source_a = LineString::new(vec![coord! {x: 2.0, y: 0.0}, coord! {x: 42.0, y: 50.0}]);
+
+        let source_b = LineString::new(vec![coord! {x: -2.0, y: 0.0}, coord! {x: 38.0, y: 50.0}]);
+
+        let sources = vec![source_a, source_b];
+
+        let anime = Anime::new(
+            sources.into_iter(),
+            target.into_iter(),
+            5.0,  // distance_tolerance
+            20.0, // angle_tolerance
+        );
+
+        let matches = anime.matches.get().unwrap();
+
+        // Both diagonal parallels should match correctly
+        if let Some(target_matches) = matches.get(&0) {
+            assert_eq!(
+                target_matches.len(),
+                2,
+                "Both diagonal parallel lines should match"
+            );
+        } else {
+            panic!("Target should have matches");
+        }
+    }
 }

--- a/rust/src/structs.rs
+++ b/rust/src/structs.rs
@@ -112,7 +112,7 @@ mod tests {
     fn test_tarline_distance() {
         let tarline = TarLine(
             Line::new(coord! {x: 0.0, y: 0.0}, coord! {x: 10.0, y: 0.0}),
-            1.0
+            1.0,
         );
         let other = Line::new(coord! {x: 0.0, y: 3.0}, coord! {x: 10.0, y: 3.0});
 


### PR DESCRIPTION
This PR closes #59 , supersedes #60 and supersedes #61. 

It fixes the near vertical line matching issue by using the absolute value of slopes rather than their actual calculated value. This is because there is no inherent sense of directionality that we can glean from the simple feature standard. A line that consists of C1, C2 is identical to a line composed of the coords C2, C1.

