### PR TITLE
fix: use normalized source angle for projection-axis selection

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -191,7 +191,7 @@ fn find_candidate_matches(
 
                 // if distance is less than or equal to tolerance, add the key
                 if d <= distance_tolerance {
-                    let shared_len = if x_deg.abs() <= 45.0 {
+                    let shared_len = if x_deg <= 45.0 {
                         if x_overlap.is_some() {
                             let (p1, p2) =
                                 solve_no_y_overlap(x_overlap.unwrap(), cx.geom(), &x_slope);

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -191,7 +191,7 @@ fn find_candidate_matches(
 
                 // if distance is less than or equal to tolerance, add the key
                 if d <= distance_tolerance {
-                    let shared_len = if x_slope.atan().to_degrees() <= 45.0 {
+                    let shared_len = if x_deg.abs() <= 45.0 {
                         if x_overlap.is_some() {
                             let (p1, p2) =
                                 solve_no_y_overlap(x_overlap.unwrap(), cx.geom(), &x_slope);


### PR DESCRIPTION
Attempt to fix #66.


<details>
  <summary>AI Output</summary>

`kimi-k2.7-code` was used to generate this PR. It's output was as follows: 

Update after further diagnosis with Kimi K2.7 / automated testing: opened PR #67 with a one-line fix that makes the axis selector use the same normalized angle as the parallelism check.

```rust
- let shared_len = if x_slope.atan().to_degrees() <= 45.0 {
+ let shared_len = if x_deg.abs() <= 45.0 {
```

The bug is confirmed for any steep negative-slope source placed to the **right** of the target (i.e. leaning toward it), not just the original coordinates. I tested the original negative line `101 → 100.5`, variants at `101 → 100.0`, `102 → 101.5`, and `101.5 → 100.5`; every one returned `shared_len = 0`. The mirror image placed on the **left** of the target (`99 → 99.5`, `98 → 98.5`) returned `shared_len ≈ 50`.

After rebuilding the R package with the patched Rust code, the original reprex now returns:

| target_id | source_id | shared_len |
|-----------|-----------|------------|
|         1 |         1 |    50.0025 |
|         1 |         2 |    50.0025 |

`cargo test` passes (40/40). 

</details>